### PR TITLE
Fix: Target Features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ once_cell = "1.18.0"
 dioxus-search-macro = { path = "search-macro" }
 dioxus-search-shared = { path = "search-shared" }
 
-[target.'cfg(arch = "wasm32")'.dependencies]
+[target.'cfg(target_family = "wasm")'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }
 
 [workspace]

--- a/search-shared/Cargo.toml
+++ b/search-shared/Cargo.toml
@@ -17,5 +17,5 @@ yazi = "0.1.5"
 scraper = "0.17.1"
 log = "0.4.19"
 
-[target.'cfg(arch = "wasm32")'.dependencies]
+[target.'cfg(target_family = "wasm")'.dependencies]
 getrandom = { version = "0.2", features = ["js"] }


### PR DESCRIPTION
Fixes `getrandom` from compiling without the `js` feature on Rust edition 2021. This is a blocker for updating `dioxus-docsite`'s Rust edition to 2021.

This does not break crates using the 2018 Rust edition. (Tested with docsite)