### PR TITLE
Fix route mapping with hash segments

### DIFF
--- a/search-shared/src/lib.rs
+++ b/search-shared/src/lib.rs
@@ -353,7 +353,10 @@ impl<R: Routable> SearchIndexMapping<R> for BaseDirectoryMapping {
     }
 
     fn map_route(&self, route: R) -> Option<PathBuf> {
-        let route = PathBuf::from(route.to_string()).join("index.html");
+        let route = route.to_string();
+        let (route, _) = route.split_once('#')?;
+        let (route, _) = route.split_once('?')?;
+        let route = PathBuf::from(route).join("index.html");
         Some(route)
     }
 }


### PR DESCRIPTION
This PR fixes the url to html file mapping we use for generating the search index. It currently tries to include the hash and query segment in the file name. This issue is causing the search index on the doc site to fail